### PR TITLE
ci: load shared commitlint preset in GitHub Actions

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,0 @@
-module.exports = { extends: ['@fingerprintjs/commit-lint-dx-team'] };

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,1 @@
+export default { extends: ['@fingerprintjs/commit-lint-dx-team'] };


### PR DESCRIPTION
- Rename `commitlint.config.js` to `commitlint.config.mjs` so [wagoid/commitlint-github-action](https://github.com/wagoid/commitlint-github-action/blob/v6.1.0/action.yml) loads `@fingerprintjs/commit-lint-dx-team` instead of falling back to `@commitlint/config-conventional`.

### Discussion point: 100 vs 200 character body

The shared preset already allows 200-character body and header lines. CI was still enforcing 100 because the action default config file is `commitlint.config.mjs`, and that file did not exist. Worth a follow-up in [dx-team-toolkit](https://github.com/fingerprintjs/dx-team-toolkit) to pass `configFile` explicitly so other SDKs with a `.js` config stop hitting the same fallback.