### PR TITLE
INTER-2051: Add SDK version support and EOL table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,10 +336,10 @@ composer install
 
 ## Version support
 
-| SDK major version | Server API version | Status | End of support | Notes |
-|---|---|---|---|---|
-| v7.x (current) | [v4](https://docs.fingerprint.com/reference/server-api) | Supported | - | - |
-| v1.x-v6.x | [v3](https://docs.fingerprint.com/reference/v3/server-api) | Deprecated (security fixes only). See the [migration guide](https://docs.fingerprint.com/reference/php-server-sdk#migration-guide-for-php-sdk-v7). | To be decided | Maintained in the [old repository](https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk) |
+| SDK major version | Server API version | Status | End of support |
+|---|---|---|---|
+| v7.x (current) | [v4](https://docs.fingerprint.com/reference/server-api) | Supported | - |
+| v1.x-v6.x | [v3](https://docs.fingerprint.com/reference/v3/server-api) | Deprecated (security fixes only). See the [migration guide](https://docs.fingerprint.com/reference/php-server-sdk#migration-guide-for-php-sdk-v7). | To be decided |
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -334,6 +334,13 @@ composer install
 ./vendor/bin/phpunit
 ```
 
+## Version support
+
+| SDK major version | Server API version | Status | End of support | Notes |
+|---|---|---|---|---|
+| v7.x (current) | [v4](https://docs.fingerprint.com/reference/server-api) | Supported | - | - |
+| v1.x-v6.x | [v3](https://docs.fingerprint.com/reference/v3/server-api) | Deprecated (security fixes only). See the [migration guide](https://docs.fingerprint.com/reference/php-server-sdk#migration-guide-for-php-sdk-v7). | To be decided | Maintained in the [old repository](https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk) |
+
 ## Support
 
 To report problems, ask questions or provide feedback, please use [Issues](https://github.com/fingerprintjs/php-sdk/issues).

--- a/template/README.mustache
+++ b/template/README.mustache
@@ -292,6 +292,13 @@ composer install
 ./vendor/bin/phpunit
 ```
 
+## Version support
+
+| SDK major version | Server API version | Status | End of support | Notes |
+|---|---|---|---|---|
+| v7.x (current) | [v4](https://docs.fingerprint.com/reference/server-api) | Supported | - | - |
+| v1.x-v6.x | [v3](https://docs.fingerprint.com/reference/v3/server-api) | Deprecated (security fixes only). See the [migration guide](https://docs.fingerprint.com/reference/php-server-sdk#migration-guide-for-php-sdk-v7). | To be decided | Maintained in the [old repository](https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk) |
+
 ## Support
 
 To report problems, ask questions or provide feedback, please use [Issues]({{gitRepoBaseURL}}/{{gitUserId}}/{{gitRepoId}}/issues).

--- a/template/README.mustache
+++ b/template/README.mustache
@@ -294,10 +294,10 @@ composer install
 
 ## Version support
 
-| SDK major version | Server API version | Status | End of support | Notes |
-|---|---|---|---|---|
-| v7.x (current) | [v4](https://docs.fingerprint.com/reference/server-api) | Supported | - | - |
-| v1.x-v6.x | [v3](https://docs.fingerprint.com/reference/v3/server-api) | Deprecated (security fixes only). See the [migration guide](https://docs.fingerprint.com/reference/php-server-sdk#migration-guide-for-php-sdk-v7). | To be decided | Maintained in the [old repository](https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk) |
+| SDK major version | Server API version | Status | End of support |
+|---|---|---|---|
+| v7.x (current) | [v4](https://docs.fingerprint.com/reference/server-api) | Supported | - |
+| v1.x-v6.x | [v3](https://docs.fingerprint.com/reference/v3/server-api) | Deprecated (security fixes only). See the [migration guide](https://docs.fingerprint.com/reference/php-server-sdk#migration-guide-for-php-sdk-v7). | To be decided |
 
 ## Support
 


### PR DESCRIPTION
This PR addresses concerns raised in [INTER-2051](https://fingerprintjs.atlassian.net/browse/INTER-2051). This is one PR as a part of a thread of PRs that will need to be made for each SDK.

Adds a "Version support" section to the README with a single table showing which SDK major versions map to which Server API version, their current status, and end-of-support info.

[INTER-2051]: https://fingerprintjs.atlassian.net/browse/INTER-2051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ